### PR TITLE
feat: Detect EAC3 as an audio codec + test case

### DIFF
--- a/src/audioCodec.ts
+++ b/src/audioCodec.ts
@@ -109,5 +109,9 @@ export function parseAudioCodec(title: string): { codec?: AudioCodec; source?: s
     return { codec: AudioCodec.VORBIS, source: groups['vorbis'] };
   }
 
+  if (groups['eac3']) {
+    return { codec: AudioCodec.EAC3, source: groups['eac3'] };
+  }
+
   return {};
 }

--- a/test/audioCodec.spec.ts
+++ b/test/audioCodec.spec.ts
@@ -34,6 +34,10 @@ const audioCodecCases: Array<[string, ReturnType<typeof parseAudioCodec>]> = [
     'Ex Machina 2015 UHD BluRay 2160p DTS-X 7 1 HDR x265 10bit-CHD',
     { codec: AudioCodec.DTSHD, source: 'DTS-X' },
   ],
+  [
+    'Frozen.2.2019.German.DL.EAC3.1080p.DSNP.WEB.H265-ZeroTwo',
+    { codec: AudioCodec.EAC3, source: 'EAC3' }
+  ]
 ];
 
 for (const [title, result] of audioCodecCases) {


### PR DESCRIPTION
The EAC3 audio codec is currently not detected. This PR attempts to fix that.

![2024 02 16-16-12-00](https://github.com/scttcper/video-filename-parser/assets/160252916/8582e07e-4721-42fe-a8e0-65dee01f46d4)

